### PR TITLE
make debit return  WalletTransaction 

### DIFF
--- a/src/Services/EasyWalletOperation.php
+++ b/src/Services/EasyWalletOperation.php
@@ -50,7 +50,7 @@ class EasyWalletOperation
             $transactionNumber = $this->generateRandomTransactionNumber();
 
             $wallet->decrement('balance', $amount);
-            $transaction =  $this->recordTransaction(new RecordTransactionData(
+            return $this->recordTransaction(new RecordTransactionData(
                 wallet: $wallet,
                 amount: -$amount,
                 type: 'debit',
@@ -58,7 +58,6 @@ class EasyWalletOperation
                 fromWalletId: $wallet->id,
                 transactionNumber: $transactionNumber
             ));
-            return $transaction;
         });
     }
 


### PR DESCRIPTION
In some cases, the user may need the transaction ID. 
To accommodate this, we return the entire WalletTransaction object, which includes the ID along with all other transaction details.